### PR TITLE
Some bugs are in websocket

### DIFF
--- a/websocket/client/websocket_client.go
+++ b/websocket/client/websocket_client.go
@@ -51,10 +51,12 @@ func main() {
 		case <-done:
 			return
 		case t := <-ticker.C:
-			err := c.WriteMessage(websocket.TextMessage, []byte(t.String()))
-			if err != nil {
-				logging.Infof("write err: %s", err)
-				return
+			for i := 0; i < 10; i++ {
+				err := c.WriteMessage(websocket.TextMessage, []byte(t.String()))
+				if err != nil {
+					logging.Infof("write err: %s", err)
+					return
+				}
 			}
 		case <-interrupt:
 			logging.Infof("interrupt")


### PR DESCRIPTION
你好，
我发现 websocket 在客户端发送数据过快的时候，服务器端会出现问题。

出现问题代码 在 [](https://github.com/gnet-io/gnet-examples/blob/v2/websocket/server/websocket.go#L60)

应该是 github.com/gobwas/ws 在epoll 的下，读取数据导致的。

也许这个bug我该 提给   github.com/gobwas/ws 。

我看了一眼 https://github.com/gnet-io/gnet-examples/blob/v2/simple_protocol/protocol/proto.go
估计要想让 gnet完美支持 websocket ，需要自己写 codec 。

